### PR TITLE
feat(#1): script npm start

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 ## Quizz Boxes
 
-Run with `babel-node --stage 1 index`
+Run with `npm start`.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "start": "babel-node --stage 1 index",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
@@ -16,6 +17,6 @@
     "rimraf": "^2.4.1"
   },
   "devDependencies": {
-    "babel-core": "^5.6.15"
+    "babel": "^5.6.14"
   }
 }


### PR DESCRIPTION
Permet de démarrer par une commande standard bien connue plutôt qu'une commande documentée dans le readme avec des installations globales pré-requises.
